### PR TITLE
[FIX] Fix font.hpp compilation for msvc

### DIFF
--- a/include/renderer/font.hpp
+++ b/include/renderer/font.hpp
@@ -5,6 +5,7 @@
 using Microsoft::WRL::ComPtr;
 
 #include <memory>
+#include <string>
 #include <unordered_map>
 
 #ifndef NOMINMAX


### PR DESCRIPTION
Under msvc std::string is not defined in this header.